### PR TITLE
Use alpine:3.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:3.5
 MAINTAINER Erik Osterman "erik@cloudposse.com"
 
 USER root


### PR DESCRIPTION
## what
* Downgrade from `alpine:edge` to `alpine:3.5`

## why
* Production stability https://wiki.alpinelinux.org/wiki/Edge

Constant errors on edge:
```
ERROR: http://dl-cdn.alpinelinux.org/alpine/edge/main: temporary error (try again later)
WARNING: Ignoring APKINDEX.066df28d.tar.gz: No such file or directory
fetch http://dl-cdn.alpinelinux.org/alpine/edge/community/x86_64/APKINDEX.tar.gz
ERROR: http://dl-cdn.alpinelinux.org/alpine/edge/community: temporary error (try again later)
WARNING: Ignoring APKINDEX.b53994b4.tar.gz: No such file or directory
```


## who
@cloudposse/engineering 