### PR TITLE
Enable keep-alives

### DIFF
--- a/rootfs/etc/ssh/sshd_config
+++ b/rootfs/etc/ssh/sshd_config
@@ -59,7 +59,7 @@ TCPKeepAlive yes
 UsePrivilegeSeparation sandbox
 PermitUserEnvironment no
 #Compression delayed
-ClientAliveInterval 0
+ClientAliveInterval 30
 ClientAliveCountMax 3
 UseDNS no
 #PidFile /run/sshd.pid


### PR DESCRIPTION
## what
* Enable server-side keep-alives

## why
* Reduce likelihood of SSH connections from being terminated by load balancers that kill idle connections 

## who
@goruha 