### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ The enforcer is able to send notifications to a slack channel anytime there is a
 
 | ENV                        |      Description                                    |  Default  |
 |----------------------------|:----------------------------------------------------|:---------:|
+| `SLACK_ENABLED`            | Enabled Slack integration                           | `false`   |
 | `SLACK_HOOK`               | Slack integration method (e.g. `pam`, `sshrc`)      | `sshrc`   |
 | `SLACK_WEBHOOK_URL`        | Webhook URL                                         |           |
 | `SLACK_USERNAME`           | Slack handle of bot (defaults to short-dns name)    |           |


### PR DESCRIPTION
By default SLACK_ENABLED is set to 'false' which can be disappointing when a SLACK_WEBHOOK is specified but no notification is send. So it could be useful to specify the enabled flag for users which wants to enable Slack notifications.