### PR TITLE
Add compose example to build bastion from source

### DIFF
--- a/examples/compose/README.md
+++ b/examples/compose/README.md
@@ -31,7 +31,7 @@ Connect to bastion via ssh by running.
 ```
 bastion/examples/compose$ ssh <github_user_name>@<docker_ip> -p 1234
 ```
-<docker-ip> may be one of the following;
+`docker_ip` may be one of the following;
 1. localhost
 2. `bastion/examples/compose$ docker-machine ip`
 
@@ -58,11 +58,19 @@ To stop the containers and remove attached volumes, run;
 bastion/examples/compose$ docker-compose down -v
 ```
 
+## Advanced Usage
+
 ### Build from source
-To stop the containers and remove attached volumes, run;
+To build the bastion container from source files in this repo, run;  
 ```
-bastion/examples/compose$ docker-compose down -v
+bastion/examples/compose$ docker-compose -f local.yml up -d --build
 ```
+This may take a while.  
+To clean up, run;  
+```
+bastion/examples/compose$ docker-compose -f local.yml down -v
+```
+
 
 ## References
 https://github.com/cloudposse/github-authorized-keys

--- a/examples/compose/README.md
+++ b/examples/compose/README.md
@@ -61,19 +61,17 @@ bastion/examples/compose$ docker-compose down -v
 ## Advanced Usage
 
 ### Build from source
-To build the bastion container from source files in this repo, run;  
+To build the bastion container from source files in this repo;  
+1. Add ```SSH_AUDIT_ENABLED=false``` in your ```bastion.env```. [See Issue #46.](https://github.com/cloudposse/bastion/issues/46)
+2. Run (Note: This may take a while) ;  
 ```
 bastion/examples/compose$ docker-compose -f local.yml up -d --build
 ```
-This may take a while.  
-To clean up, run;  
+ 
+3. To clean up, run;  
 ```
 bastion/examples/compose$ docker-compose -f local.yml down -v
 ```
-
-
-## References
-https://github.com/cloudposse/github-authorized-keys
 
 
 ## References

--- a/examples/compose/local.yml
+++ b/examples/compose/local.yml
@@ -1,0 +1,38 @@
+version: "2"
+volumes:
+  home:
+  etc:
+services:
+  bastion:
+    build: ../../
+    image: local/bastion
+    ports:
+      - "1234:22"
+    env_file:
+      - bastion.env
+    volumes:
+      - home:/home
+      - etc:/etc
+  gak:
+    image: cloudposse/github-authorized-keys
+    ports:
+      - "301:301"
+    volumes:
+      - home:/home
+      - etc:/etc
+    env_file:
+      - gak.env
+    links:
+      - "etcd:etcd"
+    restart: always
+  etcd:
+    image: quay.io/coreos/etcd:v2.3.7
+    command:
+      - "--advertise-client-urls=http://0.0.0.0:2379,http://0.0.0.0:4001"
+      - "--listen-client-urls=http://0.0.0.0:2379,http://0.0.0.0:4001"
+    ports:
+      - "2379:2379"
+      - "2380:2380"
+      - "4001:4001"
+      - "7001:7001"
+    restart: always

--- a/examples/compose/local.yml
+++ b/examples/compose/local.yml
@@ -13,6 +13,9 @@ services:
     volumes:
       - home:/home
       - etc:/etc
+      - "./scripts/ssh-authorized-keys-command:/etc/init.d/ssh-authorized-keys-command"
+      - "./scripts/ssh-api-url:/etc/init.d/ssh-api-url"
+      - "./scripts/ssh-log-level:/etc/init.d/ssh-log-level"
   gak:
     image: cloudposse/github-authorized-keys
     ports:


### PR DESCRIPTION
Enhance docker-compose example to build bastion from source.
We should look at Issue #46 to see why below error occurs when 
SSH_AUDIT_ENABLED=true
```
bastion_1  | Initializing ssh-audit
bastion_1  | - Enabling SSH Audit Logs
bastion_1  | Password: chsh: PAM: Authentication token manipulation error
bastion_1  | FATAL: Failed to initialize
```
@osterman