### PR TITLE
Reset the Failures counter after login. Fixes #41 

### DIFF
--- a/rootfs/etc/pam.d/sshd
+++ b/rootfs/etc/pam.d/sshd
@@ -3,5 +3,6 @@ auth       include     rate-limit
 auth       required    pam_env.so
 session    optional    pam_umask.so umask=0066
 auth       include     mfa
+account    required    pam_tally2.so
 session    include     sudosh
 session    include     enforcer


### PR DESCRIPTION
With the way pam_tally2 is currently configured, the counter gets increased every time a user logs in.
I'm adding the part which actually reset the counter after a successful login.

This fixes #41.

This is how to verify the failures number increases every time one logs in (e.g. when the connection is established, but before the mfa challenge is answered):
```
bash-4.4# pam_tally2 --user root
Login           Failures Latest failure     From
root                1    11/08/19 07:32:46  172.17.0.1
```
With this PR in place, you will see the counter getting back to 0 after a successful login (after mfa challenge is successfully answered).