### PR TITLE
git.io->cloudposse.tools update

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -1,3 +1,4 @@
+
 ---
 #
 # This is the canonical configuration for the `README.md`


### PR DESCRIPTION
Change all references to  , since  redirects will stop working on April 29th, 2022. See here for more information: DEV-143