### PR TITLE
Update sshd_config

### DIFF
--- a/rootfs/etc/ssh/sshd_config
+++ b/rootfs/etc/ssh/sshd_config
@@ -25,7 +25,7 @@ PermitRootLogin yes
 PermitUserRC no
 StrictModes no
 MaxAuthTries 6
-MaxSessions 10
+MaxSessions 1
 
 PubkeyAuthentication yes
 


### PR DESCRIPTION
This disables session multiplexing to fix #42.

More information regarding `MaxSessions`:

> MaxSessions
    Specifies the maximum number of open shell, login or subsystem (e.g. sftp) sessions permitted per network connection. Multiple sessions may be established by clients that support connection multiplexing. Setting MaxSessions to 1 will effectively disable session multiplexing, whereas setting it to 0 will prevent all shell, login and subsystem sessions while still permitting forwarding. The default is 10.


## what
* Disables session multiplexing.

## why
* To ensure 2FA is always used.

## references
* https://github.com/cloudposse/bastion/issues/42
* https://man.openbsd.org/sshd_config
