### PR TITLE
Support release branches

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -18,6 +18,7 @@ version-resolver:
     - 'bug'
     - 'hotfix'
   default: 'minor'
+filter-by-commitish: true
 
 categories:
 - title: '🚀 Enhancements'

--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -1,8 +1,10 @@
 name: feature-branch
 on:
   pull_request:
-    branches: [ main ]
-    types: [ opened, synchronize, reopened ]
+    branches:
+      - main
+      - release/**
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 permissions:
   pull-requests: write

--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -23,6 +23,10 @@ jobs:
     secrets:
       github_access_token: ${{ secrets.REPO_ACCESS_TOKEN }}
 
+  ci-labels:
+    steps:
+      - uses: cloudposse/github-action-release-label-validator@v1
+
   ci-build-test:
     runs-on: ubuntu-latest
     steps:
@@ -49,4 +53,4 @@ jobs:
       - run: |
           echo '${{ toJSON(needs) }}'  # easier debug
           ! ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
-    needs: [ ci-readme, ci-codeowners, ci-build-test ]
+    needs: [ ci-readme, ci-codeowners, ci-labels, ci-build-test ]

--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -24,6 +24,7 @@ jobs:
       github_access_token: ${{ secrets.REPO_ACCESS_TOKEN }}
 
   ci-labels:
+    runs-on: ubuntu-latest
     steps:
       - uses: cloudposse/github-action-release-label-validator@v1
 

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -1,7 +1,14 @@
 name: release-branch
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - release/**
+    paths-ignore:
+      - '.github/**'
+      - 'docs/**'
+      - 'examples/**'
+      - 'test/**'
 
 permissions:
   contents: write

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -1,0 +1,13 @@
+name: release-published
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  controller-release-branches:
+    uses: cloudposse/github-actions-workflows/.github/workflows/controller-release-branches.yml@main

--- a/.github/workflows/tag-pushed.yml
+++ b/.github/workflows/tag-pushed.yml
@@ -18,16 +18,12 @@ jobs:
         id: check_tag
         run: |
           highest_tag=$(git tag -l | grep -E "^[0-9]+\.[0-9]+\.[0-9]+$" | sort -rV | head -n1)
-          highest_major=$(echo $highest_tag | cut -d '.' -f 1)
-          
-          echo $highest_tag
-          echo $highest_major
+          highest_major=$(echo $highest_tag | cut -d '.' -f 1)          
+          test -n "$highest_major"
           
           current_tag=${{ github.ref_name }}
           current_major=$(echo $current_tag | cut -d '.' -f 1)
-
-          echo $current_tag
-          echo $current_major
+          test -n "$current_major"
           
           if [ $current_major -ge $highest_major ]; then
             echo "is_latest_major=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/tag-pushed.yml
+++ b/.github/workflows/tag-pushed.yml
@@ -16,9 +16,9 @@ jobs:
         id: check_tag
         shell: bash
         run: |
-          highest_tag=$(git tag -l | grep -E "^\d+\.\d+\.\d+$" | sort -rV | head -n1)
+          highest_tag="$(git tag -l | grep -E "^\d+\.\d+\.\d+$" | sort -rV | head -n1)"
           highest_major=$(echo "$highest_tag" | cut -d '.' -f 1)
-          current_tag=${{ github.ref_name }}
+          current_tag="${{ github.ref_name }}"
           current_major=$(echo "$current_tag" | cut -d '.' -f 1)
           echo $highest_tag
           echo $highest_major

--- a/.github/workflows/tag-pushed.yml
+++ b/.github/workflows/tag-pushed.yml
@@ -17,13 +17,13 @@ jobs:
         shell: bash
         run: |
           set -x
-          highest_tag=$(git tag -l | grep -E "^\d+\.\d+\.\d+$" | sort -rV | head -n1)
+          highest_tag="$(git tag -l | grep -E "^\d+\.\d+\.\d+$" | sort -rV | head -n1)"
           highest_major=$(echo $highest_tag | cut -d '.' -f 1)
           
           echo $highest_tag
           echo $highest_major
           
-          current_tag=${{ github.ref_name }}
+          current_tag="${{ github.ref_name }}"
           current_major=$(echo $current_tag | cut -d '.' -f 1)
 
           echo $current_tag

--- a/.github/workflows/tag-pushed.yml
+++ b/.github/workflows/tag-pushed.yml
@@ -32,7 +32,6 @@ jobs:
         with:
           images: ${{ github.repository }}
           tags: |
-            # set latest tag for default branch
             type=raw,value=latest,enable=${{ steps.check_tag.outputs.is_latest_major }}
             type=semver,pattern={{major}}
             type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/tag-pushed.yml
+++ b/.github/workflows/tag-pushed.yml
@@ -12,14 +12,31 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Check if tag belongs to the latest major release or higher
+        id: check_tag
+        run: |
+          highest_tag=$(git tag -l | grep -E "^\d+\.\d+\.\d+$" | sort -rV | head -n1)
+          highest_major=$(echo "$highest_tag" | cut -d '.' -f 1)
+          current_tag="${{ github.ref }}"
+          current_major=$(echo "$current_tag" | cut -d '.' -f 1)
+          
+          if [ $current_major -ge $highest_major ]; then
+            echo "::set-output name=is_latest_major::true"
+          else
+            echo "::set-output name=is_latest_major::false"
+          fi
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
         with:
           images: ${{ github.repository }}
           tags: |
-            type=semver,pattern={{version}}
+            # set latest tag for default branch
+            type=raw,value=latest,enable=${{ steps.check_tag.outputs.is_latest_major }}
+            type=semver,pattern={{major}}
             type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{version}}
 
       - name: Login to DockerHub
         uses: docker/login-action@v2

--- a/.github/workflows/tag-pushed.yml
+++ b/.github/workflows/tag-pushed.yml
@@ -18,8 +18,12 @@ jobs:
         run: |
           highest_tag=$(git tag -l | grep -E "^\d+\.\d+\.\d+$" | sort -rV | head -n1)
           highest_major=$(echo "$highest_tag" | cut -d '.' -f 1)
-          current_tag="${{ github.ref_name }}"
+          current_tag=${{ github.ref_name }}
           current_major=$(echo "$current_tag" | cut -d '.' -f 1)
+          echo $highest_tag
+          echo $highest_major
+          echo $current_tag
+          echo $current_major
           
           if [ $current_major -ge $highest_major ]; then
             echo "is_latest_major=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/tag-pushed.yml
+++ b/.github/workflows/tag-pushed.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           grep --help
           git tag -l
-          git tag -l | grep -E "^\d+\.\d+\.\d+$"
+          git tag -l | grep -E "^\d+\.\d+\.\d+$" || true
           highest_tag=$(git tag -l | grep -E "^\d+\.\d+\.\d+$" | sort -rV | head -n1)
           highest_major=$(echo $highest_tag | cut -d '.' -f 1)
           

--- a/.github/workflows/tag-pushed.yml
+++ b/.github/workflows/tag-pushed.yml
@@ -14,6 +14,7 @@ jobs:
 
       - name: Check if tag belongs to the latest major release or is higher
         id: check_tag
+        shell: bash
         run: |
           highest_tag=$(git tag -l | grep -E "^\d+\.\d+\.\d+$" | sort -rV | head -n1)
           highest_major=$(echo "$highest_tag" | cut -d '.' -f 1)

--- a/.github/workflows/tag-pushed.yml
+++ b/.github/workflows/tag-pushed.yml
@@ -31,6 +31,8 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ${{ github.repository }}
+          flavor: |
+            latest=false
           tags: |
             type=raw,value=latest,enable=${{ steps.check_tag.outputs.is_latest_major }}
             type=semver,pattern={{major}}

--- a/.github/workflows/tag-pushed.yml
+++ b/.github/workflows/tag-pushed.yml
@@ -11,12 +11,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - name: Check if tag belongs to the latest major release or is higher
         id: check_tag
         run: |
+          git tag -l 
+          grep -h
           git tag -l | grep -E "^\d+\.\d+\.\d+$"
           highest_tag=$(git tag -l | grep -E "^\d+\.\d+\.\d+$" | sort -rV | head -n1)
           highest_major=$(echo $highest_tag | cut -d '.' -f 1)

--- a/.github/workflows/tag-pushed.yml
+++ b/.github/workflows/tag-pushed.yml
@@ -11,17 +11,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Check if tag belongs to the latest major release or is higher
         id: check_tag
         run: |
-          highest_tag="$(git tag -l | grep -E "^\d+\.\d+\.\d+$" | sort -rV | head -n1)"
+          highest_tag=$(git tag -l | grep -E "^\d+\.\d+\.\d+$" | sort -rV | head -n1)
           highest_major=$(echo $highest_tag | cut -d '.' -f 1)
           
           echo $highest_tag
           echo $highest_major
           
-          current_tag="${{ github.ref_name }}"
+          current_tag=${{ github.ref_name }}
           current_major=$(echo $current_tag | cut -d '.' -f 1)
 
           echo $current_tag

--- a/.github/workflows/tag-pushed.yml
+++ b/.github/workflows/tag-pushed.yml
@@ -17,9 +17,8 @@ jobs:
       - name: Check if tag belongs to the latest major release or is higher
         id: check_tag
         run: |
-          grep --help
           git tag -l
-          git tag -l | grep -E "^\d+\.\d+\.\d+$" || true
+          git tag -l | grep -E "^[0-9]+\.[0-9]+\.[0-9]+$"
           highest_tag=$(git tag -l | grep -E "^\d+\.\d+\.\d+$" | sort -rV | head -n1)
           highest_major=$(echo $highest_tag | cut -d '.' -f 1)
           

--- a/.github/workflows/tag-pushed.yml
+++ b/.github/workflows/tag-pushed.yml
@@ -16,12 +16,16 @@ jobs:
         id: check_tag
         shell: bash
         run: |
-          highest_tag="$(git tag -l | grep -E "^\d+\.\d+\.\d+$" | sort -rV | head -n1)"
-          highest_major=$(echo "$highest_tag" | cut -d '.' -f 1)
-          current_tag="${{ github.ref_name }}"
-          current_major=$(echo "$current_tag" | cut -d '.' -f 1)
+          set -x
+          highest_tag=$(git tag -l | grep -E "^\d+\.\d+\.\d+$" | sort -rV | head -n1)
+          highest_major=$(echo $highest_tag | cut -d '.' -f 1)
+          
           echo $highest_tag
           echo $highest_major
+          
+          current_tag=${{ github.ref_name }}
+          current_major=$(echo $current_tag | cut -d '.' -f 1)
+
           echo $current_tag
           echo $current_major
           

--- a/.github/workflows/tag-pushed.yml
+++ b/.github/workflows/tag-pushed.yml
@@ -17,9 +17,7 @@ jobs:
       - name: Check if tag belongs to the latest major release or is higher
         id: check_tag
         run: |
-          git tag -l
-          git tag -l | grep -E "^[0-9]+\.[0-9]+\.[0-9]+$"
-          highest_tag=$(git tag -l | grep -E "^\d+\.\d+\.\d+$" | sort -rV | head -n1)
+          highest_tag=$(git tag -l | grep -E "^[0-9]+\.[0-9]+\.[0-9]+$" | sort -rV | head -n1)
           highest_major=$(echo $highest_tag | cut -d '.' -f 1)
           
           echo $highest_tag

--- a/.github/workflows/tag-pushed.yml
+++ b/.github/workflows/tag-pushed.yml
@@ -14,9 +14,7 @@ jobs:
 
       - name: Check if tag belongs to the latest major release or is higher
         id: check_tag
-        shell: bash
         run: |
-          set -x
           highest_tag="$(git tag -l | grep -E "^\d+\.\d+\.\d+$" | sort -rV | head -n1)"
           highest_major=$(echo $highest_tag | cut -d '.' -f 1)
           

--- a/.github/workflows/tag-pushed.yml
+++ b/.github/workflows/tag-pushed.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Check if tag belongs to the latest major release or higher
+      - name: Check if tag belongs to the latest major release or is higher
         id: check_tag
         run: |
           highest_tag=$(git tag -l | grep -E "^\d+\.\d+\.\d+$" | sort -rV | head -n1)

--- a/.github/workflows/tag-pushed.yml
+++ b/.github/workflows/tag-pushed.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           highest_tag=$(git tag -l | grep -E "^\d+\.\d+\.\d+$" | sort -rV | head -n1)
           highest_major=$(echo "$highest_tag" | cut -d '.' -f 1)
-          current_tag="${{ github.ref }}"
+          current_tag="${{ github.ref_name }}"
           current_major=$(echo "$current_tag" | cut -d '.' -f 1)
           
           if [ $current_major -ge $highest_major ]; then

--- a/.github/workflows/tag-pushed.yml
+++ b/.github/workflows/tag-pushed.yml
@@ -21,9 +21,9 @@ jobs:
           current_major=$(echo "$current_tag" | cut -d '.' -f 1)
           
           if [ $current_major -ge $highest_major ]; then
-            echo "::set-output name=is_latest_major::true"
+            echo "is_latest_major=true" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=is_latest_major::false"
+            echo "is_latest_major=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Docker meta

--- a/.github/workflows/tag-pushed.yml
+++ b/.github/workflows/tag-pushed.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Check if tag belongs to the latest major release or is higher
         id: check_tag
         run: |
-          git tag -l
+          git tag -l | grep -E "^\d+\.\d+\.\d+$"
           highest_tag=$(git tag -l | grep -E "^\d+\.\d+\.\d+$" | sort -rV | head -n1)
           highest_major=$(echo $highest_tag | cut -d '.' -f 1)
           

--- a/.github/workflows/tag-pushed.yml
+++ b/.github/workflows/tag-pushed.yml
@@ -11,12 +11,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Check if tag belongs to the latest major release or is higher
         id: check_tag
         run: |
-          git tag -l 
-          grep -h
+          grep --help
+          git tag -l
           git tag -l | grep -E "^\d+\.\d+\.\d+$"
           highest_tag=$(git tag -l | grep -E "^\d+\.\d+\.\d+$" | sort -rV | head -n1)
           highest_major=$(echo $highest_tag | cut -d '.' -f 1)

--- a/.github/workflows/tag-pushed.yml
+++ b/.github/workflows/tag-pushed.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Check if tag belongs to the latest major release or is higher
         id: check_tag
         run: |
+          git tag -l
           highest_tag=$(git tag -l | grep -E "^\d+\.\d+\.\d+$" | sort -rV | head -n1)
           highest_major=$(echo $highest_tag | cut -d '.' -f 1)
           


### PR DESCRIPTION
## what
* Support release branches
* Retag docker `latest` tag only for tags within latest major or higher

## why
* Old versions backports workflow 

