### PR TITLE
Add libqrencode to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,7 @@ LABEL maintainer="erik@cloudposse.com"
 USER root
 
 ## Install dependencies
-RUN apk --update add curl drill groff util-linux bash xauth gettext openssl-dev shadow linux-pam sudo && \
+RUN apk --update add curl drill groff util-linux bash xauth gettext openssl-dev shadow linux-pam libqrencode sudo && \
     rm -rf /etc/ssh/ssh_host_*_key* && \
     rm -f /usr/bin/ssh-agent && \
     rm -f /usr/bin/ssh-keyscan && \


### PR DESCRIPTION
## what
Add libqrencode package into dockerfile

## why
Be able to see the QRCODE in the terminal, as the Google charts API from google-authenticator-libpam does not work anymore. ([Check the issue](https://github.com/google/google-authenticator-libpam/issues/126))

## references

