### PR TITLE
Fix release workflows

### DIFF
--- a/.github/workflows/tag-pushed.yml
+++ b/.github/workflows/tag-pushed.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - '\d+\.\d+\.\d+'
+      - 'v\d+\.\d+\.\d+'      
 
 jobs:
   ci-build-push:


### PR DESCRIPTION
## what
* Trigger docker build on `vX.X.X`  tags

## why
* Cloudposse now use `v` prefix as standard for all versions


