### PR TITLE
Duo version update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apk --update add --virtual .build-deps build-base automake autoconf libtool 
 ##
 FROM builder AS duo-builder
 
-ARG DUO_VERSION=2.0.4
+ARG DUO_VERSION=2.2.3
 RUN wget https://dl.duosecurity.com/duo_unix-${DUO_VERSION}.tar.gz && \
     mkdir -p src && \
     tar -zxf duo_unix-${DUO_VERSION}.tar.gz --strip-components=1 -C src


### PR DESCRIPTION
Upgrade Duo for DigiCert certificate pinning and Verify Push

## what
* This upgrades the Duo Unix bundle to version 2.2.3
* This release includes an updated certificate bundle so the software will continue to work after Feb 2, 2026.
* Releases above 2.2.0 also allow for a Verify Push feature, should clients wish to take advantage of it (https://duo.com/docs/duounix)

## why
* Duo clients on 2.0.4 will stop working after Feb 2, 2026

## references
* https://help.duo.com/s/article/9451?language=en_US

