### PR TITLE
Add pull-requests permission to workflow

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -9,6 +9,7 @@ permissions:
   id-token: write
   contents: write
   packages: write
+  pull-requests: write
   
 jobs:
   terraform-module:


### PR DESCRIPTION
## what
* Add `pull-request: write` permission to the release workflow

## why
* Release action adds a comment to the PRs

## Release
* https://github.com/cloudposse/bastion/actions/runs/21491892803